### PR TITLE
Use jna.library.path to load library supporting Linux, OSX, Windows

### DIFF
--- a/src/main/java/io/woo/htmltopdf/wkhtmltopdf/WkHtmlToPdfLoader.java
+++ b/src/main/java/io/woo/htmltopdf/wkhtmltopdf/WkHtmlToPdfLoader.java
@@ -35,7 +35,8 @@ class WkHtmlToPdfLoader {
                 throw new RuntimeException(e);
             }
         }
-        return (WkHtmlToPdf)Native.loadLibrary(libraryFile.getAbsolutePath(), WkHtmlToPdf.class);
+        System.setProperty("jna.library.path", libraryFile.getParent());
+        return Native.loadLibrary("wkhtmltox", WkHtmlToPdf.class);
     }
 
     static String getLibraryResource() {


### PR DESCRIPTION
Hi,

While running unit tests on MacOS 10.13.4, an issue (see below) occurred in loading the library. After reading JNA loadLibrary specification, I made a change with minimal impact that is successfully unit tested on Ubuntu 18.04, Windows 10, MacOS 10.13.4.

Could you please have a look at the PR?

regards,
Ralph

java.lang.Exception: Unexpected exception, expected<io.woo.htmltopdf.HtmlToPdfException> but was<java.lang.UnsatisfiedLinkError>
...
Caused by: java.lang.UnsatisfiedLinkError: Unable to load library '/var/folders/02/mz02h42s0mb8jhlmwqyn4s4m0_lw0_/T/io.woo.htmltopdf/wkhtmltox/0.12.4/libwkhtmltox.so': Native library (var/folders/02/mz02h42s0mb8jhlmwqyn4s4m0_lw0_/T/io.woo.htmltopdf/wkhtmltox/0.12.4/libwkhtmltox.so) not found in resource path ([file:/Applications/IntelliJ%20IDEA.app/Contents/lib/idea_rt.jar, file:/Applications/IntelliJ%20IDEA.app/Contents/plugins/junit/lib/junit-rt.jar, file:/Applications/IntelliJ%20IDEA.app/Contents/plugins/junit/lib/junit5-rt.jar, file:/Library/Java/JavaVirtualMachines/zulu1.8.0_162.jdk/Contents/Home/jre/lib/charsets.jar, ...])
	at com.sun.jna.NativeLibrary.loadLibrary(NativeLibrary.java:303)

Java: zulu1.8.0_162.jdk 